### PR TITLE
Simplify links to social icon resources

### DIFF
--- a/src/DeveloperKorea.WebApp/Shared/MainLayout.razor
+++ b/src/DeveloperKorea.WebApp/Shared/MainLayout.razor
@@ -3,8 +3,8 @@
 <div class="page">
     <main>
         <div class="top-row px-4">
-            <a href="https://github.com/microsoft/developerkorea" target="_blank"><img src="https://cdn.simpleicons.org/github/181717" width="32" /></a>
-            <a href="https://youtube.com/@@MicrosoftDeveloperKorea" target="_blank"><img src="https://cdn.simpleicons.org/youtube/FF0000" width="32" /></a>
+            <a href="https://github.com/microsoft/developerkorea" target="_blank"><img src="https://cdn.simpleicons.org/github" width="32" /></a>
+            <a href="https://youtube.com/@@MicrosoftDeveloperKorea" target="_blank"><img src="https://cdn.simpleicons.org/youtube" width="32" /></a>
         </div>
 
         <article class="content px-4">


### PR DESCRIPTION
These two icon links can be simplified. The color parameter is unnecessary here since the color value you use is the same as the default value.

Here is the documentation: https://github.com/LitoMore/simple-icons-cdn